### PR TITLE
add wrapper for globalrefgetstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ refget.egg-info/
 coverage.xml
 
 .vscode/settings.json
+/test_fasta/base.farg

--- a/refget/__init__.py
+++ b/refget/__init__.py
@@ -9,6 +9,8 @@ from .utilities import *
 from ._version import __version__
 from .models import SequenceCollection
 
+from .refget_store import *
+
 try:
     # Requires optional dependencies, so we catch the ImportError
     from .refget_router import create_refget_router, get_dbagent

--- a/refget/refget_store.py
+++ b/refget/refget_store.py
@@ -1,6 +1,9 @@
 # This is simply a wrapper for gtars.refget 's GlobalRefgetStore for user convenience.
+import logging
 import sys
 from .const import GTARS_INSTALLED
+
+_LOGGER = logging.getLogger(__name__)
 
 if GTARS_INSTALLED:
     from gtars.refget import (
@@ -8,12 +11,6 @@ if GTARS_INSTALLED:
         StorageMode,
         RetrievedSequence,
     )
-
-    # We can now create aliases for the classes to expose them directly under `refget`.
-    GlobalRefgetStore = GlobalRefgetStore
-    StorageMode = StorageMode
-    RetrievedSequence = RetrievedSequence
-
 else:
     # gtars is not installed. We'll create a dummy class that raises an error.
     # This prevents the user's code from crashing immediately upon import.
@@ -29,11 +26,6 @@ else:
     class RetrievedSequence:
         pass
 
-    class SequenceCollection:
-        pass
-
-    # We can provide a more helpful message here
-    sys.stderr.write(
+    _LOGGER.warning(
         "Warning: 'gtars' package not found. GlobalRefgetStore and associated functionality will not be available.\n"
     )
-    sys.stderr.flush()

--- a/refget/refget_store.py
+++ b/refget/refget_store.py
@@ -1,0 +1,39 @@
+# This is simply a wrapper for gtars.refget 's GlobalRefgetStore for user convenience.
+import sys
+from .const import GTARS_INSTALLED
+
+if GTARS_INSTALLED:
+    from gtars.refget import (
+        GlobalRefgetStore,
+        StorageMode,
+        RetrievedSequence,
+    )
+
+    # We can now create aliases for the classes to expose them directly under `refget`.
+    GlobalRefgetStore = GlobalRefgetStore
+    StorageMode = StorageMode
+    RetrievedSequence = RetrievedSequence
+
+else:
+    # gtars is not installed. We'll create a dummy class that raises an error.
+    # This prevents the user's code from crashing immediately upon import.
+    class GlobalRefgetStore:
+        def __init__(self, *args, **kwargs):
+            raise ImportError("gtars is required for this function.")
+
+    # Also define dummy classes for the associated types
+    class StorageMode:
+        Raw = None
+        Encoded = None
+
+    class RetrievedSequence:
+        pass
+
+    class SequenceCollection:
+        pass
+
+    # We can provide a more helpful message here
+    sys.stderr.write(
+        "Warning: 'gtars' package not found. GlobalRefgetStore and associated functionality will not be available.\n"
+    )
+    sys.stderr.flush()

--- a/tests/local/test_local_models_gtars.py
+++ b/tests/local/test_local_models_gtars.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from refget.models import SequenceCollection as pythonSequenceCollection
 
+from refget.refget_store import GlobalRefgetStore, StorageMode
+
 try:
     from gtars.refget import (
         SequenceCollection as gtarsSequenceCollection,
@@ -49,3 +51,11 @@ class TestRustPySequenceCollection:
             bridged_seq_col.sorted_name_length_pairs_digest
             == python_seq_col.sorted_name_length_pairs_digest
         )
+
+
+@pytest.mark.skipif(not _RUST_BINDINGS_AVAILABLE, reason="gtars is not installed")
+class TestRustRefgetStore:
+    def test_store(self):
+        # just make sure this is callable if gtars is installed.
+        s = GlobalRefgetStore(mode=StorageMode.Raw)
+        s.import_fasta("test_fasta/base.fa")


### PR DESCRIPTION
add wrapping for the gtars GlobalRefgetStore bindings so the user can simply access everything from refget python package